### PR TITLE
fix(ra-data-graphql-amp): createMany and updateMany

### DIFF
--- a/src/buildVariables.ts
+++ b/src/buildVariables.ts
@@ -295,7 +295,18 @@ const buildCreateUpdateVariables = (
             ...acc,
             [`${key}Ids`]: params.data[key].map(({ id }: any) => id),
           };
-        } else {
+        }
+
+        if (aorFetchType === 'UPDATE') {
+          return {
+            ...acc,
+            [key]: {
+               set: params.data[key],
+            }
+          }
+        }
+
+        if (aorFetchType === 'CREATE') {
           return {
             ...acc,
             [key]: {


### PR DESCRIPTION
what happened?
on our blog server:
chose post > edit > update tags > go back to post and chose the post you have just updated again > edit > see that the update did not happen

To handle change (update) on 'toMany' relation (TagUpdateManyWithoutPostsInput)
and creation of 'toMany' relation (TagCreateNestedManyWithoutPostsInput)

I separated the two options: 
creation stays with 'connect' and update was changed to set

```
if (aorFetchType === 'UPDATE') {
          return {
            ...acc,
            [key]: {
               set: params.data[key],
            }
          }
        }

        if (aorFetchType === 'CREATE') {
          return {
            ...acc,
            [key]: {
              connect: params.data[key],
            }
          }
        }
```