### PR TITLE
chore: update options type to allow params overload

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,6 @@ import buildDataProvider, {
   IntrospectionOptions,
   Options,
 } from 'ra-data-graphql';
-import { AmplicationRaDataGraphQLProviderOptions } from 'types';
 import defaultAmplicationBuildQuery from './buildQuery';
 
 /**
@@ -40,9 +39,7 @@ const defaultAmplicationOptions: Options = {
   introspection,
 };
 
-export default (
-  options: AmplicationRaDataGraphQLProviderOptions
-): Promise<DataProvider> => {
+export default (options: Options): Promise<DataProvider> => {
   return buildDataProvider(merge({}, defaultAmplicationOptions, options)).then(
     (defaultDataProvider) => {
       return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,3 @@
-import { ApolloClient } from '@apollo/client';
-
 export enum FetchType {
   GET_LIST = 'GET_LIST',
   GET_ONE = 'GET_ONE',
@@ -14,11 +12,4 @@ export enum FetchType {
 
 export type Variables = {
   [key: string]: any;
-};
-
-/**
- * This options overwrite the default amplication options
- */
-export type AmplicationRaDataGraphQLProviderOptions = {
-  client: ApolloClient<any>;
 };


### PR DESCRIPTION
Related: https://github.com/amplication/private-issues/issues/104

This PR update the options parameter type,  to allow customisation like specifing a schema instead of rely on introspection.